### PR TITLE
Several local function variables are not var scoped and literal data cannot be added with indexing a file

### DIFF
--- a/components/cfsolrlib.cfc
+++ b/components/cfsolrlib.cfc
@@ -115,7 +115,7 @@
 	<cfargument name="fmap" required="false" type="struct" hint="The mappings of document metadata fields to index fields." />
 	<cfargument name="saveMetadata" required="false" type="boolean" default="true" hint="Store non-mapped metadata in dynamic fields" />
 	<cfargument name="metadataPrefix" required="false" type="string" default="attr_" hint="Metadata dynamic field prefix" />
-	
+	<cfargument name="literalData" required="false" type="struct" hint="A struct of data to add as literal fields. The struct key will be used as the field name, and the value as the field's value. NOTE: You cannot have a literal field with the same name as a metadata field.  Solr will throw an error if you attempt to override metadata with a literal field" />
 	<cfset var docRequest = THIS.javaLoaderInstance.create("org.apache.solr.client.solrj.request.ContentStreamUpdateRequest").init("/update/extract") />
 	<cfset var thisKey = "" />
 	<cfset docRequest.addFile(createObject("java","java.io.File").init(ARGUMENTS.file)) />
@@ -126,6 +126,11 @@
 	<cfif isDefined("ARGUMENTS.fmap")>
 		<cfloop list="#structKeyList(ARGUMENTS.fmap)#" index="thisKey">
 			<cfset docRequest.setParam("fmap.#thisKey#",ARGUMENTS.fmap[thisKey]) />
+		</cfloop>
+	</cfif>
+	<cfif isDefined("ARGUMENTS.literalData")>
+		<cfloop list="#structKeyList(ARGUMENTS.literalData)#" index="thisKey">
+			<cfset docRequest.setParam("literal.#thisKey#",ARGUMENTS.literalData[thisKey]) />
 		</cfloop>
 	</cfif>
 	


### PR DESCRIPTION
These commits fix two issues.  First, several functions had local variables that were not var scoped.  The second addresses issue #1 and allows for literal data to be added when indexing a file.
